### PR TITLE
Add a script to build rpm for RHEL

### DIFF
--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -1,0 +1,22 @@
+#! /bin/sh -ex
+
+# script to build rpm for RHEL
+
+TOPDIR=$(pwd)
+PACKAGE_VERSION=$(./version-gen.sh)
+DISTRO_SHORT=el$(sed -rn 's/[^0-9]*([0-9]).*/\1/p' /etc/redhat-release)
+
+rm -rf {BUILD,RPMS,SOURCES,SRPMS}
+mkdir {BUILD,RPMS,SOURCES,SRPMS}
+./build.sh && ./configure && make dist
+mv collectd-*.tar.bz2 SOURCES
+rpmbuild -ba --with write_tsdb --with nfs --without java \
+  --without amqp --without gmond --without nut --without pinba \
+  --without ping --without varnish --without dpdkstat \
+  --without turbostat --without redis --without write_redis \
+  --without gps --without lvm --without modbus --without mysql \
+  --without ime \
+  --define "_topdir $TOPDIR " \
+  --define="rev $PACKAGE_VERSION" \
+  --define="dist .$DISTRO_SHORT" \
+  contrib/redhat/collectd.spec


### PR DESCRIPTION
### Overview
To improve convenience for users, I added  a script to build rpm for RHEL.
This script assume the build dependency is installed.

### How to use
Just run `./rpmbuild.sh`